### PR TITLE
GitHub Actions - Build, Lint and Deploy to Chromatic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,3 +15,7 @@ jobs:
         run: yarn build
       - name: Lint
         run: yarn lint
+      - uses: chromaui/action@v1
+        with:
+          projectToken: t00yilwkcv
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,16 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0 # Required to retrieve git history (for Chromatic)
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
       - name: Install node_modules
         run: yarn install --frozen-lockfile
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:
@@ -19,7 +19,6 @@ jobs:
         run: yarn lint
       - name: Deploy to Chromatic
         uses: chromaui/action@v1
-        if: ${{ github.event_name == 'pull_request' }}
         with:
           projectToken: t00yilwkcv
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - uses: actions/cache@v2
+      - name: Cache Yarn modules cache
+        uses: actions/cache@v2
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # Checks-out the Repository
+      - uses: actions/checkout@v2
+      - name: Install node_modules
+        run: yarn install --frozen-lockfile
+      - name: Build
+        run: yarn build
+      - name: Lint
+        run: yarn lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Checks-out the Repository
-      - uses: actions/checkout@v2
+      - name: Checkout Repository
+        uses: actions/checkout@v2
       - name: Install node_modules
         run: yarn install --frozen-lockfile
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,8 @@ jobs:
       # Checks-out the Repository
       - name: Checkout Repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required to retrieve git history (for Chromatic)
       - name: Install node_modules
         run: yarn install --frozen-lockfile
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -17,7 +17,9 @@ jobs:
         run: yarn build
       - name: Lint
         run: yarn lint
-      - uses: chromaui/action@v1
+      - name: Deploy to Chromatic
+        uses: chromaui/action@v1
+        if: ${{ github.event_name == 'pull_request' }}
         with:
           projectToken: t00yilwkcv
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add a GitHub action to build, lint and deploy Storybook on Chromatic.

This also adds Chromatic PR Checks as displayed at the bottom of this PR.

**To be done later:**
Follow instructions [here](https://www.chromatic.com/docs/ci#maintain-a-clean-master-branch) to auto-accept changes on protected branches, such as `master` and `develop`. This will let us continue to squash & merge PRs without having to review Chromatic Changes twice: once for the PR and another time for the develop build.

I am waiting that all PRs that don't yet have the Chromatic checks to be merged before doing that, to prevent us to merge non-validated changes in `develop`. 