### PR TITLE
Actions Timeout

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       # Checks-out the Repository
       - name: Checkout Repository


### PR DESCRIPTION
Set a timeout of 10 minutes for build, to prevent never ending builds.

Will prevent build issues like [this](https://github.com/Trampoline-CX/Cubes/actions/runs/152872897) (caused by Chromatic for a weird reason).