### PR TITLE
Fix Dialogs on Native

### DIFF
--- a/src/components/base/Modal/Modal.tsx
+++ b/src/components/base/Modal/Modal.tsx
@@ -1,0 +1,9 @@
+import WebModal from 'modal-react-native-web'
+import { Modal as RNModal, Platform } from 'react-native'
+
+if (Platform.OS === 'web') {
+  // Set App Element of Modal (for React Native Web)
+  WebModal.setAppElement('body')
+}
+
+export const Modal = Platform.OS === 'web' ? WebModal : RNModal

--- a/src/components/overlays/Dialog/Dialog.tsx
+++ b/src/components/overlays/Dialog/Dialog.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import Modal from 'modal-react-native-web'
 import { View } from 'react-native'
 import { useStyles } from '../../../theme'
 import { shameStyles } from '../../../theme/shame-styles'
+import { Modal } from '../../base/Modal/Modal'
 import { Header } from './Header/Header'
 import { FooterProps, Footer } from './Footer/Footer'
 import { Section, SectionProps } from './Section/Section'
@@ -35,9 +35,6 @@ export type DialogProps = {
 } & FooterProps
 
 const { backdropColor, defaultWidth, minWidth } = shameStyles.dialog
-
-// Set App Element of Modal (for React Native Web)
-Modal.setAppElement('body')
 
 /**
  * Show interactive content on top of an existing screen.


### PR DESCRIPTION
I was certain the library used for Dialogs was using the native `Modal` on Native apps, but in fact it does not support native Apps.

I created a file exporting the correct `Modal` according to the Platform we're on.